### PR TITLE
add handling for cookies to allow downloading premium content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ go.work
 
 # Directory contained scraped content
 scraped/
+# vscode settings
+.vscode

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Use "sbstck-dl [command] --help" for more information about a command.
 
 ### Downloading posts
 
-You can provide the url of a single post or the main url of the Substack you want to download. If attempting to download premium content, get the cookies used during the `GET` request for your article in the browser and provide it with the `-c` flag.
+You can provide the url of a single post or the main url of the Substack you want to download. 
+
+To download or access premium content, first log into to your Substack account with access to premium posts. Then, capture the cookies used during the `GET` request for any of the articles and pass it via the `-c` flag.
 
 ```bash
 Usage:
@@ -46,7 +48,7 @@ Flags:
   -h, --help            help for download
   -o, --output string   Specify the download directory (default ".")
   -u, --url string      Specify the Substack url
-  -c, --cookie string   Specify your Substack cookie 
+  -c, --cookies string  Specify the request cookies (format: key1=value1; key2=value2; ...) 
 
 Global Flags:
       --after string    Download posts published after this date (format: YYYY-MM-DD)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Flags:
   -h, --help            help for download
   -o, --output string   Specify the download directory (default ".")
   -u, --url string      Specify the Substack url
+  -c, --cookie string   Specify your Substack cookie 
 
 Global Flags:
       --after string    Download posts published after this date (format: YYYY-MM-DD)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use "sbstck-dl [command] --help" for more information about a command.
 
 ### Downloading posts
 
-You can provide the url of a single post or the main url of the Substack you want to download.
+You can provide the url of a single post or the main url of the Substack you want to download. If attempting to download premium content, get the cookies used during the `GET` request for your article in the browser and provide it with the `-c` flag.
 
 ```bash
 Usage:

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -62,7 +62,7 @@ var (
 				// we are downloading the entire archive
 				var downloadedPostsCount int
 				dateFilterfunc := makeDateFilterFunc(beforeDate, afterDate)
-				urls, err := extractor.GetAllPostsURLs(ctx, downloadUrl, dateFilterfunc, cookie)
+				urls, err := extractor.GetAllPostsURLs(ctx, downloadUrl, dateFilterfunc)
 				if err != nil {
 					log.Fatalln(err)
 				}

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -17,6 +17,7 @@ var (
 	downloadUrl  string
 	format       string
 	outputFolder string
+	cookie       string
 	dryRun       bool
 	downloadCmd  = &cobra.Command{
 		Use:   "download",
@@ -38,7 +39,7 @@ var (
 					fmt.Println("Warning: --before and --after flags are ignored when downloading a single post")
 				}
 
-				post, err := extractor.ExtractPost(ctx, downloadUrl)
+				post, err := extractor.ExtractPost(ctx, downloadUrl, cookie)
 				if err != nil {
 					log.Fatalln(err)
 				}
@@ -61,7 +62,7 @@ var (
 				// we are downloading the entire archive
 				var downloadedPostsCount int
 				dateFilterfunc := makeDateFilterFunc(beforeDate, afterDate)
-				urls, err := extractor.GetAllPostsURLs(ctx, downloadUrl, dateFilterfunc)
+				urls, err := extractor.GetAllPostsURLs(ctx, downloadUrl, dateFilterfunc, cookie)
 				if err != nil {
 					log.Fatalln(err)
 				}
@@ -77,7 +78,7 @@ var (
 					progressbar.OptionSetWidth(25),
 					progressbar.OptionSetDescription("downloading"),
 					progressbar.OptionShowBytes(true))
-				for result := range extractor.ExtractAllPosts(ctx, urls) {
+				for result := range extractor.ExtractAllPosts(ctx, urls, cookie) {
 					select {
 					case <-ctx.Done():
 						log.Fatalln("context cancelled")
@@ -116,6 +117,7 @@ var (
 func init() {
 	rootCmd.AddCommand(downloadCmd)
 	downloadCmd.PersistentFlags().StringVarP(&downloadUrl, "url", "u", "", "Specify the Substack url")
+	downloadCmd.PersistentFlags().StringVarP(&cookie, "cookie", "c", "", "Specify the Substack request cookie(s)")
 	downloadCmd.PersistentFlags().StringVarP(&format, "format", "f", "html", "Specify the output format (options: \"html\", \"md\", \"txt\"")
 	downloadCmd.PersistentFlags().StringVarP(&outputFolder, "output", "o", ".", "Specify the download directory")
 	downloadCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "Enable dry run")

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -41,6 +41,7 @@ var (
 				if (beforeDate != "" || afterDate != "") && verbose {
 					fmt.Println("Warning: --before and --after flags are ignored when downloading a single post")
 				}
+
 				post, err := extractor.ExtractPost(ctx, downloadUrl)
 				if err != nil {
 					log.Fatalln(err)

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -17,14 +17,17 @@ var (
 	downloadUrl  string
 	format       string
 	outputFolder string
-	cookie       string
 	dryRun       bool
+	cookies      string
 	downloadCmd  = &cobra.Command{
 		Use:   "download",
 		Short: "Download individual posts or the entire public archive",
 		Long:  `You can provide the url of a single post or the main url of the Substack you want to download.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			startTime := time.Now()
+			if cookies != "" {
+				fetcher.SetCookie(cookies)
+			}
 
 			// if url contains "/p/", we are downloading a single post
 			if strings.Contains(downloadUrl, "/p/") {
@@ -38,21 +41,21 @@ var (
 				if (beforeDate != "" || afterDate != "") && verbose {
 					fmt.Println("Warning: --before and --after flags are ignored when downloading a single post")
 				}
-				res := <-extractor.ExtractAllPosts(ctx, []string{downloadUrl}, cookie)
-				if res.Err != nil {
-					log.Fatalln(res.Err)
+				post, err := extractor.ExtractPost(ctx, downloadUrl)
+				if err != nil {
+					log.Fatalln(err)
 				}
 				downloadTime := time.Since(startTime)
 				if verbose {
 					fmt.Printf("Downloaded post %s in %s\n", downloadUrl, downloadTime)
 				}
 
-				path := makePath(res.Post, outputFolder, format)
+				path := makePath(post, outputFolder, format)
 				if verbose {
 					fmt.Printf("Writing post to file %s\n", path)
 				}
 
-				res.Post.WriteToFile(path, format)
+				post.WriteToFile(path, format)
 
 				if verbose {
 					fmt.Println("Done in ", time.Since(startTime))
@@ -77,7 +80,7 @@ var (
 					progressbar.OptionSetWidth(25),
 					progressbar.OptionSetDescription("downloading"),
 					progressbar.OptionShowBytes(true))
-				for result := range extractor.ExtractAllPosts(ctx, urls, cookie) {
+				for result := range extractor.ExtractAllPosts(ctx, urls) {
 					select {
 					case <-ctx.Done():
 						log.Fatalln("context cancelled")
@@ -116,10 +119,10 @@ var (
 func init() {
 	rootCmd.AddCommand(downloadCmd)
 	downloadCmd.PersistentFlags().StringVarP(&downloadUrl, "url", "u", "", "Specify the Substack url")
-	downloadCmd.PersistentFlags().StringVarP(&cookie, "cookie", "c", "", "Specify the Substack request cookie(s)")
 	downloadCmd.PersistentFlags().StringVarP(&format, "format", "f", "html", "Specify the output format (options: \"html\", \"md\", \"txt\"")
 	downloadCmd.PersistentFlags().StringVarP(&outputFolder, "output", "o", ".", "Specify the download directory")
 	downloadCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "Enable dry run")
+	downloadCmd.PersistentFlags().StringVarP(&cookies, "cookies", "c", "", "Specify the request cookie(s) (format: 'key1=value1; key2=value2; ...')")
 	downloadCmd.MarkPersistentFlagRequired("url")
 }
 

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -94,7 +94,6 @@ var (
 						continue
 					}
 					bar.Add(1)
-					downloadedPostsCount++
 					if verbose {
 						fmt.Printf("Downloading post %s\n", result.Post.CanonicalUrl)
 					}
@@ -105,7 +104,14 @@ var (
 						fmt.Printf("Writing post to file %s\n", path)
 					}
 
-					post.WriteToFile(path, format)
+					err = post.WriteToFile(path, format)
+					if err != nil {
+						if verbose {
+							fmt.Printf("Failed to write '%s', got error '%s'", path, err.Error())
+						}
+					} else {
+						downloadedPostsCount++
+					}
 				}
 				if verbose {
 					fmt.Println("Downloaded", downloadedPostsCount, "posts, out of", len(urls))

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -38,22 +38,21 @@ var (
 				if (beforeDate != "" || afterDate != "") && verbose {
 					fmt.Println("Warning: --before and --after flags are ignored when downloading a single post")
 				}
-
-				post, err := extractor.ExtractPost(ctx, downloadUrl, cookie)
-				if err != nil {
-					log.Fatalln(err)
+				res := <-extractor.ExtractAllPosts(ctx, []string{downloadUrl}, cookie)
+				if res.Err != nil {
+					log.Fatalln(res.Err)
 				}
 				downloadTime := time.Since(startTime)
 				if verbose {
 					fmt.Printf("Downloaded post %s in %s\n", downloadUrl, downloadTime)
 				}
 
-				path := makePath(post, outputFolder, format)
+				path := makePath(res.Post, outputFolder, format)
 				if verbose {
 					fmt.Printf("Writing post to file %s\n", path)
 				}
 
-				post.WriteToFile(path, format)
+				res.Post.WriteToFile(path, format)
 
 				if verbose {
 					fmt.Println("Done in ", time.Since(startTime))

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -25,7 +25,7 @@ var (
 				fmt.Println("Getting all posts URLs...")
 			}
 			dateFilterfunc := makeDateFilterFunc(beforeDate, afterDate)
-			urls, err := extractor.GetAllPostsURLs(ctx, mainWebsite, dateFilterfunc, "")
+			urls, err := extractor.GetAllPostsURLs(ctx, mainWebsite, dateFilterfunc)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -25,7 +25,7 @@ var (
 				fmt.Println("Getting all posts URLs...")
 			}
 			dateFilterfunc := makeDateFilterFunc(beforeDate, afterDate)
-			urls, err := extractor.GetAllPostsURLs(ctx, mainWebsite, dateFilterfunc)
+			urls, err := extractor.GetAllPostsURLs(ctx, mainWebsite, dateFilterfunc, "")
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/lib/extractor.go
+++ b/lib/extractor.go
@@ -170,9 +170,9 @@ func extractJSONString(scriptContent string) (string, error) {
 	return scriptContent[start+len("JSON.parse(\"") : end], nil
 }
 
-func (e *Extractor) ExtractPost(ctx context.Context, pageUrl string) (Post, error) {
+func (e *Extractor) ExtractPost(ctx context.Context, pageUrl, cookie string) (Post, error) {
 	// fetch page HTML content
-	body, err := e.fetcher.FetchURL(ctx, pageUrl)
+	body, err := e.fetcher.FetchURL(ctx, pageUrl, cookie)
 	if err != nil {
 		return Post{}, fmt.Errorf("failed to fetch page: %s", err)
 	}
@@ -213,7 +213,7 @@ func (e *Extractor) ExtractPost(ctx context.Context, pageUrl string) (Post, erro
 
 type DateFilterFunc func(string) bool
 
-func (e *Extractor) GetAllPostsURLs(ctx context.Context, pubUrl string, f DateFilterFunc) ([]string, error) {
+func (e *Extractor) GetAllPostsURLs(ctx context.Context, pubUrl string, f DateFilterFunc, cookie string) ([]string, error) {
 	u, err := url.Parse(pubUrl)
 	if err != nil {
 		return nil, err
@@ -225,7 +225,7 @@ func (e *Extractor) GetAllPostsURLs(ctx context.Context, pubUrl string, f DateFi
 	}
 
 	// fetch the sitemap of the publication
-	body, err := e.fetcher.FetchURL(ctx, u.String())
+	body, err := e.fetcher.FetchURL(ctx, u.String(), cookie)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ type ExtractResult struct {
 	Err  error
 }
 
-func (e *Extractor) ExtractAllPosts(ctx context.Context, urls []string) <-chan ExtractResult {
+func (e *Extractor) ExtractAllPosts(ctx context.Context, urls []string, cookie string) <-chan ExtractResult {
 	ch := make(chan ExtractResult, len(urls))
 
 	go func() {
@@ -278,7 +278,7 @@ func (e *Extractor) ExtractAllPosts(ctx context.Context, urls []string) <-chan E
 		for _, u := range urls {
 			go func(url string) {
 				defer wg.Done()
-				post, err := e.ExtractPost(ctx, url)
+				post, err := e.ExtractPost(ctx, url, cookie)
 				ch <- ExtractResult{Post: post, Err: err}
 			}(u)
 		}

--- a/lib/extractor.go
+++ b/lib/extractor.go
@@ -271,6 +271,7 @@ type ExtractResult struct {
 
 func (e *Extractor) ExtractAllPosts(ctx context.Context, urls []string) <-chan ExtractResult {
 	ch := make(chan ExtractResult, len(urls))
+
 	go func() {
 		var wg sync.WaitGroup
 		wg.Add(len(urls))

--- a/lib/extractor.go
+++ b/lib/extractor.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -171,9 +170,9 @@ func extractJSONString(scriptContent string) (string, error) {
 	return scriptContent[start+len("JSON.parse(\"") : end], nil
 }
 
-func (e *Extractor) ExtractPost(ctx context.Context, pageUrl string, cookie *http.Cookie) (Post, error) {
+func (e *Extractor) ExtractPost(ctx context.Context, pageUrl string) (Post, error) {
 	// fetch page HTML content
-	body, err := e.fetcher.FetchURL(ctx, pageUrl, cookie)
+	body, err := e.fetcher.FetchURL(ctx, pageUrl)
 	if err != nil {
 		return Post{}, fmt.Errorf("failed to fetch page: %s", err)
 	}
@@ -226,7 +225,7 @@ func (e *Extractor) GetAllPostsURLs(ctx context.Context, pubUrl string, f DateFi
 	}
 
 	// fetch the sitemap of the publication
-	body, err := e.fetcher.FetchURL(ctx, u.String(), nil)
+	body, err := e.fetcher.FetchURL(ctx, u.String())
 	if err != nil {
 		return nil, err
 	}
@@ -270,23 +269,15 @@ type ExtractResult struct {
 	Err  error
 }
 
-func (e *Extractor) ExtractAllPosts(ctx context.Context, urls []string, cookieStr string) <-chan ExtractResult {
+func (e *Extractor) ExtractAllPosts(ctx context.Context, urls []string) <-chan ExtractResult {
 	ch := make(chan ExtractResult, len(urls))
-	var cookie *http.Cookie
-	var err error
-	if cookieStr != "" {
-		cookie, err = parseCookie(cookieStr, "substack.sid")
-		if err != nil {
-			fmt.Printf("%+v", err)
-		}
-	}
 	go func() {
 		var wg sync.WaitGroup
 		wg.Add(len(urls))
 		for _, u := range urls {
 			go func(url string) {
 				defer wg.Done()
-				post, err := e.ExtractPost(ctx, url, cookie)
+				post, err := e.ExtractPost(ctx, url)
 				ch <- ExtractResult{Post: post, Err: err}
 			}(u)
 		}
@@ -295,4 +286,10 @@ func (e *Extractor) ExtractAllPosts(ctx context.Context, urls []string, cookieSt
 	}()
 
 	return ch
+}
+
+func (e *Extractor) SetCookie(cookieStr string) {
+	if e.fetcher != nil {
+		e.fetcher.SetCookie(cookieStr)
+	}
 }

--- a/lib/extractor.go
+++ b/lib/extractor.go
@@ -213,7 +213,7 @@ func (e *Extractor) ExtractPost(ctx context.Context, pageUrl, cookie string) (Po
 
 type DateFilterFunc func(string) bool
 
-func (e *Extractor) GetAllPostsURLs(ctx context.Context, pubUrl string, f DateFilterFunc, cookie string) ([]string, error) {
+func (e *Extractor) GetAllPostsURLs(ctx context.Context, pubUrl string, f DateFilterFunc) ([]string, error) {
 	u, err := url.Parse(pubUrl)
 	if err != nil {
 		return nil, err
@@ -225,7 +225,7 @@ func (e *Extractor) GetAllPostsURLs(ctx context.Context, pubUrl string, f DateFi
 	}
 
 	// fetch the sitemap of the publication
-	body, err := e.fetcher.FetchURL(ctx, u.String(), cookie)
+	body, err := e.fetcher.FetchURL(ctx, u.String(), "")
 	if err != nil {
 		return nil, err
 	}

--- a/lib/fetcher.go
+++ b/lib/fetcher.go
@@ -96,7 +96,7 @@ func (f *Fetcher) FetchURLs(ctx context.Context, urls []string, cookie string) <
 		eg.Go(func() error {
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			body, err := f.FetchURL(ctx, u, cookie)
+			body, err := f.FetchURL(ctx, u, nil)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/lib/fetcher.go
+++ b/lib/fetcher.go
@@ -121,9 +121,11 @@ func (f *Fetcher) FetchURLs(ctx context.Context, urls []string) <-chan FetchResu
 // FetchURL fetches the specified URL and returns the response body as io.ReadCloser and any encountered error.
 // It uses rate limiting and retry mechanisms to handle rate limits and transient failures.
 func (f *Fetcher) FetchURL(ctx context.Context, url string) (io.ReadCloser, error) {
+
 	var body io.ReadCloser
 	var err error
 	var retryCounter int
+
 	var nextRetryWait time.Duration
 	operation := func() error {
 		if retryCounter >= defaultMaxRetryCount {
@@ -152,7 +154,9 @@ func (f *Fetcher) FetchURL(ctx context.Context, url string) (io.ReadCloser, erro
 			}
 		}
 	}
+
 	backoff.RetryNotify(operation, f.BackoffCfg, notify)
+
 	return body, err
 }
 

--- a/lib/fetcher.go
+++ b/lib/fetcher.go
@@ -157,11 +157,11 @@ func (f *Fetcher) FetchURL(ctx context.Context, url, cookie string) (io.ReadClos
 	return body, err
 }
 
+// Retrieve the cookie with the targetKey from a cookie blob
+// Expect cookies to be set as key=value with multiple k-v pairs seperated with semi-colons
 func parseCookie(cookieString, targetKey string) (*http.Cookie, error) {
-	// Split the cookie string into individual cookies
 	cookies := strings.Split(cookieString, "; ")
 	for _, c := range cookies {
-		// Split each cookie into key and value
 		parts := strings.SplitN(c, "=", 2)
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid cookie format")

--- a/lib/fetcher.go
+++ b/lib/fetcher.go
@@ -117,7 +117,7 @@ func (f *Fetcher) FetchURLs(ctx context.Context, urls []string, cookie string) <
 
 // FetchURL fetches the specified URL and returns the response body as io.ReadCloser and any encountered error.
 // It uses rate limiting and retry mechanisms to handle rate limits and transient failures.
-func (f *Fetcher) FetchURL(ctx context.Context, url, cookie string) (io.ReadCloser, error) {
+func (f *Fetcher) FetchURL(ctx context.Context, url string, cookie *http.Cookie) (io.ReadCloser, error) {
 
 	var body io.ReadCloser
 	var err error
@@ -177,18 +177,14 @@ func parseCookie(cookieString, targetKey string) (*http.Cookie, error) {
 
 // fetch performs the actual HTTP GET request to the specified URL and returns the response body and any encountered error.
 // It checks for too many requests (status code 429) and handles it by returning a FetchError.
-func (f *Fetcher) fetch(ctx context.Context, url, cookie string) (io.ReadCloser, error) {
+func (f *Fetcher) fetch(ctx context.Context, url string, cookie *http.Cookie) (io.ReadCloser, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", userAgent)
 
-	if cookie != "" {
-		cookie, err := parseCookie(cookie, "substack.sid")
-		if err != nil {
-			return nil, err
-		}
+	if cookie != nil {
 		req.AddCookie(cookie)
 	}
 

--- a/lib/fetcher.go
+++ b/lib/fetcher.go
@@ -200,7 +200,6 @@ func (f *Fetcher) fetch(ctx context.Context, url string) (io.ReadCloser, error) 
 	if cookie := f.GetCookie(); cookie != nil {
 		req.AddCookie(cookie)
 	}
-
 	res, err := f.Client.Do(req)
 	if err != nil {
 		return nil, err

--- a/lib/fetcher.go
+++ b/lib/fetcher.go
@@ -166,10 +166,7 @@ func parseCookie(cookieString, targetKey string) (*http.Cookie, error) {
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid cookie format")
 		}
-
 		key, value := parts[0], parts[1]
-
-		// Check if this is the target cookie
 		if key == targetKey {
 			return &http.Cookie{Name: key, Value: value}, nil
 		}


### PR DESCRIPTION
adds the ability for users to pass in their cookies so paywalled content can be downloaded. users can copy the cookies header for their request in the browser and paste it into the -c flag, the cookie should be wrapped in quotes.