### PR TITLE
feat: add Substack Notes downloading functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,17 +3,18 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
-This is a Go CLI tool for downloading posts from Substack blogs. It supports downloading individual posts or entire archives, with features for private newsletters (via cookies), rate limiting, format conversion (HTML/Markdown/Text), downloading of images and file attachments locally, and creating archive index pages that link all downloaded posts with their metadata.
+This is a Go CLI tool for downloading posts from Substack blogs and Substack Notes. It supports downloading individual posts or entire archives, with features for private newsletters (via cookies), rate limiting, format conversion (HTML/Markdown/Text), downloading of images and file attachments locally, creating archive index pages that link all downloaded posts with their metadata, and downloading Substack Notes for specific users.
 
 ## Architecture
 The project follows a standard Go CLI structure:
 - `main.go`: Entry point
-- `cmd/`: Contains Cobra CLI commands (`root.go`, `download.go`, `list.go`, `version.go`)
-- `lib/`: Core library with four main components:
+- `cmd/`: Contains Cobra CLI commands (`root.go`, `download.go`, `list.go`, `version.go`, `notes.go`)
+- `lib/`: Core library with five main components:
   - `fetcher.go`: HTTP client with rate limiting, retries, and cookie support
   - `extractor.go`: Post extraction and format conversion (HTML→Markdown/Text)
   - `images.go`: Image downloading and local path management
   - `files.go`: File attachment downloading and local path management
+  - `notes.go`: Substack Notes downloading and API client
 
 ## Build and Development Commands
 
@@ -70,6 +71,15 @@ go mod download
 - Handles filename sanitization and collision avoidance
 - Integrates with existing image download workflow
 
+### Notes Client (`lib/notes.go`)
+- Downloads Substack Notes via the user activity feed API
+- Fetches activity across multiple pages with pagination support
+- Filters comments to identify actual notes vs regular post comments
+- Converts API response to structured note format with metadata
+- Supports HTML, Markdown, and plain text output formats
+- Organizes notes by timestamp with sanitized filenames
+- Extracts post context, publication info, and engagement metrics
+
 ### Archive Page Generator (`lib/extractor.go`)
 - Creates index pages linking all downloaded posts with metadata
 - Supports HTML, Markdown, and Text formats matching the selected output format
@@ -83,6 +93,7 @@ go mod download
 Uses Cobra framework:
 - `download`: Main functionality for downloading posts
 - `list`: Lists available posts from a Substack
+- `notes`: Downloads Substack Notes for a specific user
 - `version`: Shows version information
 
 ## Dependencies
@@ -148,6 +159,24 @@ go run . download --url https://example.substack.com --download-images --downloa
 
 # Download archive with specific format and custom directories
 go run . download --url https://example.substack.com --create-archive --format html --images-dir assets --files-dir attachments --output ./downloads
+```
+
+### Downloading Substack Notes
+```bash
+# Download notes for a specific user by user ID
+go run . notes --user-id 303863305 --username nweiss --output-dir ./notes
+
+# Download notes in HTML format
+go run . notes --user-id 303863305 --format html --output-dir ./notes
+
+# Download notes with filtering to get only actual notes (vs regular comments)
+go run . notes --user-id 303863305 --notes-only --output-dir ./notes
+
+# Download more pages of notes activity
+go run . notes --user-id 303863305 --max-pages 20 --verbose --output-dir ./notes
+
+# Download notes in plain text format
+go run . notes --user-id 303863305 --format txt --output-dir ./notes
 ```
 
 ### Building for release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Substack Downloader
 
-Simple CLI tool to download one or all the posts from a Substack blog.
+Simple CLI tool to download one or all the posts from a Substack blog, and download Substack Notes for specific users.
 
 ## Installation
 
@@ -31,6 +31,7 @@ Available Commands:
   download    Download individual posts or the entire public archive
   help        Help about any command
   list        List the posts of a Substack
+  notes       Download Substack Notes for a specific user
   version     Print the version number of sbstck-dl
 
 Flags:
@@ -264,6 +265,84 @@ Global Flags:
   -v, --verbose         Enable verbose output
 ```
 
+### Downloading Substack Notes
+
+You can download all Substack Notes for a specific user using their user ID. Notes are stored as comments in the user's activity feed, and this command fetches all activity and filters for notes vs regular comments.
+
+```bash
+Usage:
+  sbstck-dl notes [flags]
+
+Flags:
+  -f, --format string          Output format (html, md, txt) (default "md")
+  -h, --help                   help for notes
+      --max-pages int          Maximum pages to fetch (default 10)
+      --notes-only             Try to filter for notes vs regular comments
+  -o, --output-dir string      Output directory (default "./notes")
+      --user-id string         User ID (required, e.g., 303863305 for @nweiss)
+      --username string        Username for organizing output (e.g., nweiss)
+
+Global Flags:
+      --after string    Download posts published after this date (format: YYYY-MM-DD)
+      --before string   Download posts published before this date (format: YYYY-MM-DD)
+      --cookie_name cookieName   Either substack.sid or connect.sid, based on your cookie (required for private newsletters)
+      --cookie_val string        The substack.sid/connect.sid cookie value (required for private newsletters)
+  -x, --proxy string    Specify the proxy url
+  -r, --rate int        Specify the rate of requests per second (default 2)
+  -v, --verbose         Enable verbose output
+```
+
+#### Finding User IDs
+
+To find a user's ID, you can:
+1. Visit the user's Substack profile page
+2. Check the page source or network requests for API calls containing the user ID
+3. The user ID is typically a numeric value (e.g., 309173054)
+
+#### Notes Features
+
+**Output Formats:**
+- `html`: Full HTML format with styling and metadata
+- `md`: Markdown format with headers and links (default)
+- `txt`: Plain text format for maximum compatibility
+
+**Filtering:**
+- Use `--notes-only` to filter for actual notes vs regular post comments
+- The tool uses the activity context type to distinguish between notes and comments
+
+**Organization:**
+- Notes are saved with timestamp-based filenames: `YYYYMMDD_HHMMSS_noteID.{format}`
+- Output is organized by username or user ID in subdirectories
+- Each note includes metadata like publication context, engagement stats, and original URLs
+
+#### Examples
+
+```bash
+# Download notes for a specific user by user ID
+sbstck-dl notes --user-id 303863305 --username nweiss
+
+# Download notes in HTML format with verbose output
+sbstck-dl notes --user-id 303863305 --format html --verbose
+
+# Filter for actual notes only and fetch more pages
+sbstck-dl notes --user-id 303863305 --notes-only --max-pages 20
+
+# Download to custom directory
+sbstck-dl notes --user-id 303863305 --output-dir ./my-notes --username nweiss
+
+# Download in plain text format
+sbstck-dl notes --user-id 303863305 --format txt --output-dir ./notes-txt
+```
+
+**Directory Structure for Notes:**
+```
+notes/
+└── nweiss/              # Username or user_ID folder
+    ├── 20240115_143000_12345.md
+    ├── 20240114_120000_12346.md
+    └── 20240113_094500_12347.md
+```
+
 ### Private Newsletters
 
 In order to download the full text of private newsletters you need to provide the cookie name and value of your session.
@@ -288,6 +367,7 @@ sbstck-dl download --url https://example.substack.com --cookie_name substack.sid
 - [x] Add support for downloading images
 - [x] Add support for downloading file attachments
 - [x] Add archive index page functionality
+- [x] Add support for downloading Substack Notes
 - [x] Add tests
 - [x] Add CI
 - [x] Add documentation

--- a/cmd/notes.go
+++ b/cmd/notes.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alexferrari88/sbstck-dl/lib"
+	"github.com/spf13/cobra"
+)
+
+var (
+	notesUserID    string
+	notesUsername  string
+	notesOutputDir string
+	notesFormat    string
+	notesMaxPages  int
+	notesOnly      bool
+	notesCmd       = &cobra.Command{
+		Use:   "notes",
+		Short: "Download Substack Notes for a specific user",
+		Long: `Download all Substack Notes for a specific user using their user ID.
+
+Notes are stored as comments in the user's activity feed. This command fetches
+all activity and filters for notes vs regular comments.
+
+Example usage:
+  sbstck-dl notes --user-id 303863305 --username nweiss --output-dir ./notes
+  sbstck-dl notes --user-id 303863305 --format md --max-pages 5`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if notesUserID == "" {
+				log.Fatal("user-id is required")
+			}
+
+			// Setup output directory
+			outputDir := notesOutputDir
+			if notesUsername != "" {
+				outputDir = filepath.Join(notesOutputDir, notesUsername)
+			} else {
+				outputDir = filepath.Join(notesOutputDir, fmt.Sprintf("user_%s", notesUserID))
+			}
+
+			// Create output directory
+			if err := os.MkdirAll(outputDir, 0755); err != nil {
+				log.Fatalf("Error creating output directory: %v", err)
+			}
+
+			fmt.Printf("Downloading notes for user ID: %s\n", notesUserID)
+			fmt.Printf("Output directory: %s\n", outputDir)
+			fmt.Printf("Format: %s\n", notesFormat)
+			fmt.Println()
+
+			// Create notes client
+			notesClient := lib.NewNotesClient(fetcher)
+
+			// Fetch all notes/comments
+			items, err := notesClient.FetchAllUserActivity(notesUserID, notesMaxPages, verbose)
+			if err != nil {
+				log.Fatalf("Error fetching user activity: %v", err)
+			}
+
+			if len(items) == 0 {
+				fmt.Println("No activity found for user")
+				return
+			}
+
+			fmt.Printf("Found %d total activity items\n", len(items))
+
+			// Filter and process
+			var notes []*lib.Note
+			for _, item := range items {
+				if item.Type == "comment" && item.Comment.ID != 0 {
+					// Skip if trying to filter for notes only and this looks like a regular comment
+					if notesOnly {
+						if notesClient.IsLikelyRegularComment(item.Comment, item) {
+							continue
+						}
+					}
+
+					note := notesClient.ConvertCommentToNote(item.Comment, item)
+					if note != nil {
+						notes = append(notes, note)
+					}
+				}
+			}
+
+			fmt.Printf("Processing %d potential notes...\n", len(notes))
+			fmt.Println()
+
+			// Save all notes
+			for i, note := range notes {
+				if verbose {
+					fmt.Printf("[%d/%d] Saving note: %s\n", i+1, len(notes), note.ID)
+				}
+				if err := notesClient.SaveNote(note, outputDir, notesFormat); err != nil {
+					log.Printf("Error saving note %s: %v", note.ID, err)
+				}
+			}
+
+			fmt.Printf("Successfully saved %d items to: %s\n", len(notes), outputDir)
+		},
+	}
+)
+
+func init() {
+	notesCmd.Flags().StringVar(&notesUserID, "user-id", "", "User ID (required, e.g., 303863305 for @nweiss)")
+	notesCmd.Flags().StringVar(&notesUsername, "username", "", "Username for organizing output (e.g., nweiss)")
+	notesCmd.Flags().StringVar(&notesOutputDir, "output-dir", "./notes", "Output directory")
+	notesCmd.Flags().StringVar(&notesFormat, "format", "md", "Output format (html, md, txt)")
+	notesCmd.Flags().IntVar(&notesMaxPages, "max-pages", 10, "Maximum pages to fetch")
+	notesCmd.Flags().BoolVar(&notesOnly, "notes-only", false, "Try to filter for notes vs regular comments")
+
+	notesCmd.MarkFlagRequired("user-id")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -114,6 +114,7 @@ func init() {
 	rootCmd.AddCommand(downloadCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(notesCmd)
 }
 
 func makeDateFilterFunc(beforeDate string, afterDate string) lib.DateFilterFunc {

--- a/lib/notes.go
+++ b/lib/notes.go
@@ -1,0 +1,347 @@
+package lib
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/JohannesKaufmann/html-to-markdown"
+)
+
+// NotesClient handles downloading Substack Notes via API
+type NotesClient struct {
+	fetcher *Fetcher
+}
+
+// NewNotesClient creates a new notes client
+func NewNotesClient(fetcher *Fetcher) *NotesClient {
+	return &NotesClient{
+		fetcher: fetcher,
+	}
+}
+
+// Note represents a Substack Note
+type Note struct {
+	ID             string                 `json:"id"`
+	Body           string                 `json:"body"`
+	BodyJSON       interface{}            `json:"body_json,omitempty"`
+	Title          string                 `json:"title"`
+	Context        string                 `json:"context"`
+	CreatedAt      string                 `json:"created_at"`
+	AuthorName     string                 `json:"author_name"`
+	AuthorHandle   string                 `json:"author_handle"`
+	URL            string                 `json:"url"`
+	Type           string                 `json:"type"`
+	Publication    map[string]interface{} `json:"publication,omitempty"`
+	ReactionCount  int                    `json:"reaction_count"`
+	Restacks       int                    `json:"restacks"`
+}
+
+// NotesResponse represents the API response structure
+type NotesResponse struct {
+	Items      []ActivityItem `json:"items"`
+	NextCursor string         `json:"nextCursor"`
+}
+
+// ActivityItem represents an activity item from the user's feed
+type ActivityItem struct {
+	Type    string                 `json:"type"`
+	Comment Comment                `json:"comment,omitempty"`
+	Post    map[string]interface{} `json:"post,omitempty"`
+	Context Context                `json:"context,omitempty"`
+	Publication map[string]interface{} `json:"publication,omitempty"`
+}
+
+// Comment represents a comment/note in the activity feed
+type Comment struct {
+	ID            int                    `json:"id"`
+	Body          string                 `json:"body"`
+	BodyJSON      interface{}            `json:"body_json,omitempty"`
+	Date          string                 `json:"date"`
+	Name          string                 `json:"name"`
+	Handle        string                 `json:"handle"`
+	UserID        int                    `json:"user_id"`
+	ReactionCount int                    `json:"reaction_count"`
+	Restacks      int                    `json:"restacks"`
+}
+
+// Context represents the context of an activity item
+type Context struct {
+	Type string `json:"type"`
+}
+
+// NotesOptions contains options for downloading notes
+type NotesOptions struct {
+	UserID     string
+	Username   string
+	OutputDir  string
+	Format     string
+	MaxPages   int
+	NotesOnly  bool
+	Verbose    bool
+}
+
+// FetchAllUserActivity fetches all activity items for a user across multiple pages
+func (nc *NotesClient) FetchAllUserActivity(userID string, maxPages int, verbose bool) ([]ActivityItem, error) {
+	baseURL := fmt.Sprintf("https://substack.com/api/v1/reader/feed/profile/%s", userID)
+	headers := map[string]string{
+		"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+		"Accept":     "application/json",
+	}
+
+	var allItems []ActivityItem
+	cursor := ""
+	page := 1
+
+	for page <= maxPages {
+		reqURL := baseURL
+		if cursor != "" {
+			reqURL += "?cursor=" + url.QueryEscape(cursor)
+		}
+
+		if verbose {
+			fmt.Printf("Fetching page %d: %s\n", page, reqURL)
+		}
+
+		req, err := http.NewRequest("GET", reqURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+
+		for key, value := range headers {
+			req.Header.Set(key, value)
+		}
+
+		resp, err := nc.fetcher.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetching page %d: %w", page, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("API request failed with status %d", resp.StatusCode)
+		}
+
+		var notesResp NotesResponse
+		if err := json.NewDecoder(resp.Body).Decode(&notesResp); err != nil {
+			return nil, fmt.Errorf("decoding response: %w", err)
+		}
+
+		if len(notesResp.Items) == 0 {
+			if verbose {
+				fmt.Printf("  No items found on page %d\n", page)
+			}
+			break
+		}
+
+		allItems = append(allItems, notesResp.Items...)
+		if verbose {
+			fmt.Printf("  Found %d items on page %d (total: %d)\n", len(notesResp.Items), page, len(allItems))
+		}
+
+		cursor = notesResp.NextCursor
+		if cursor == "" {
+			if verbose {
+				fmt.Printf("  No more pages after page %d\n", page)
+			}
+			break
+		}
+
+		page++
+	}
+
+	return allItems, nil
+}
+
+// IsLikelyRegularComment detects if this is a regular comment vs a note using context.type
+func (nc *NotesClient) IsLikelyRegularComment(comment Comment, item ActivityItem) bool {
+	// The definitive way: check context.type
+	if item.Context.Type == "note" {
+		return false // This is a note, not a regular comment
+	}
+	return true // This is a regular comment
+}
+
+// ConvertCommentToNote converts a comment object to our note format
+func (nc *NotesClient) ConvertCommentToNote(comment Comment, item ActivityItem) *Note {
+	body := comment.Body
+	if body == "" || len(strings.TrimSpace(body)) < 10 {
+		return nil
+	}
+
+	// Extract post context if available
+	postContext := ""
+	if item.Post != nil {
+		if title, ok := item.Post["title"].(string); ok && title != "" {
+			postContext = fmt.Sprintf("Context: %s", title)
+		}
+	}
+
+	return &Note{
+		ID:            fmt.Sprintf("%d", comment.ID),
+		Body:          body,
+		BodyJSON:      comment.BodyJSON,
+		Title:         "", // Comments don't have titles
+		Context:       postContext,
+		CreatedAt:     comment.Date,
+		AuthorName:    comment.Name,
+		AuthorHandle:  comment.Handle,
+		URL:           fmt.Sprintf("https://substack.com/profile/%d/comment/%d", comment.UserID, comment.ID),
+		Type:          "comment_note",
+		Publication:   item.Publication,
+		ReactionCount: comment.ReactionCount,
+		Restacks:      comment.Restacks,
+	}
+}
+
+// SaveNote saves a note to file in the specified format
+func (nc *NotesClient) SaveNote(note *Note, outputDir, format string) error {
+	// Create filename
+	var createdAt time.Time
+	if note.CreatedAt != "" {
+		// Parse the date string
+		dateStr := strings.ReplaceAll(strings.ReplaceAll(note.CreatedAt, "T", " "), "Z", "")
+		if parsed, err := time.Parse("2006-01-02 15:04:05", dateStr); err == nil {
+			createdAt = parsed
+		} else {
+			createdAt = time.Now()
+		}
+	} else {
+		createdAt = time.Now()
+	}
+
+	timestamp := createdAt.Format("20060102_150405")
+	
+	// Clean ID for filename
+	re := regexp.MustCompile(`[^\w\-_]`)
+	cleanID := re.ReplaceAllString(note.ID, "")
+	if len(cleanID) > 20 {
+		cleanID = cleanID[:20]
+	}
+	
+	filename := fmt.Sprintf("%s_%s.%s", timestamp, cleanID, format)
+	filepath := filepath.Join(outputDir, filename)
+
+	var content string
+	switch format {
+	case "html":
+		content = nc.formatNoteHTML(note)
+	case "md":
+		h := html2text.NewConverter()
+		h.Opt.PrettyTables = true
+		mdContent := h.Convert(note.Body)
+		content = nc.formatNoteMarkdown(note, mdContent)
+	case "txt":
+		h := html2text.NewConverter()
+		h.Opt.PrettyTables = true
+		h.Opt.LinkStyle = "none"
+		textContent := h.Convert(note.Body)
+		content = nc.formatNoteText(note, textContent)
+	default:
+		return fmt.Errorf("unsupported format: %s", format)
+	}
+
+	return os.WriteFile(filepath, []byte(content), 0644)
+}
+
+// formatNoteHTML formats a note as HTML
+func (nc *NotesClient) formatNoteHTML(note *Note) string {
+	contextHTML := ""
+	if note.Context != "" {
+		contextHTML = fmt.Sprintf("<div class='context'><strong>Context:</strong> %s</div>", note.Context)
+	}
+	
+	pubName := ""
+	if note.Publication != nil {
+		if name, ok := note.Publication["name"].(string); ok {
+			pubName = name
+		}
+	}
+	
+	pubHTML := ""
+	if pubName != "" {
+		pubHTML = fmt.Sprintf("<div class='publication'><strong>Publication:</strong> %s</div>", pubName)
+	}
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Note by %s</title>
+</head>
+<body>
+    <div class="note">
+        <div class="author">%s (@%s)</div>
+        <div class="timestamp">%s</div>
+        %s
+        %s
+        <div class="content">%s</div>
+        <div class="stats">Reactions: %d | Restacks: %d</div>
+        <div class="url"><a href="%s">Original Comment</a></div>
+    </div>
+</body>
+</html>`, note.AuthorName, note.AuthorName, note.AuthorHandle, note.CreatedAt, contextHTML, pubHTML, note.Body, note.ReactionCount, note.Restacks, note.URL)
+}
+
+// formatNoteMarkdown formats a note as Markdown
+func (nc *NotesClient) formatNoteMarkdown(note *Note, mdContent string) string {
+	contextMD := ""
+	if note.Context != "" {
+		contextMD = fmt.Sprintf("**Context:** %s\n", note.Context)
+	}
+	
+	pubName := ""
+	if note.Publication != nil {
+		if name, ok := note.Publication["name"].(string); ok {
+			pubName = name
+		}
+	}
+	
+	pubMD := ""
+	if pubName != "" {
+		pubMD = fmt.Sprintf("**Publication:** %s\n", pubName)
+	}
+
+	return fmt.Sprintf(`# Note by %s (@%s)
+
+**Date:** %s  
+%s%s**URL:** %s
+**Stats:** %d reactions, %d restacks
+
+%s
+`, note.AuthorName, note.AuthorHandle, note.CreatedAt, contextMD, pubMD, note.URL, note.ReactionCount, note.Restacks, mdContent)
+}
+
+// formatNoteText formats a note as plain text
+func (nc *NotesClient) formatNoteText(note *Note, textContent string) string {
+	contextTxt := ""
+	if note.Context != "" {
+		contextTxt = fmt.Sprintf("Context: %s\n", note.Context)
+	}
+	
+	pubName := ""
+	if note.Publication != nil {
+		if name, ok := note.Publication["name"].(string); ok {
+			pubName = name
+		}
+	}
+	
+	pubTxt := ""
+	if pubName != "" {
+		pubTxt = fmt.Sprintf("Publication: %s\n", pubName)
+	}
+
+	return fmt.Sprintf(`Note by %s (@%s)
+Date: %s
+%s%sURL: %s
+Stats: %d reactions, %d restacks
+
+%s
+`, note.AuthorName, note.AuthorHandle, note.CreatedAt, contextTxt, pubTxt, note.URL, note.ReactionCount, note.Restacks, textContent)
+}


### PR DESCRIPTION
Add comprehensive support for downloading Substack Notes via user activity feed:
- New 'notes' command with user ID, format, and filtering options
- Support for HTML, Markdown, and plain text output formats
- Activity feed pagination with configurable max pages
- Notes vs comments filtering using activity context
- Organized output with timestamp-based filenames
- User-specific directory organization
- Comprehensive metadata extraction including engagement stats

🤖 Generated with [Claude Code](https://claude.ai/code)