### PR TITLE
feat: export native Substack media URLs on Post struct

### DIFF
--- a/lib/extractor.go
+++ b/lib/extractor.go
@@ -47,8 +47,23 @@ type Post struct {
 	Description      string `json:"description"`
 	Subtitle         string `json:"subtitle,omitempty"`
 	WordCount        int    `json:"wordcount"`
-	Title            string `json:"title"`
-	BodyHTML         string `json:"body_html"`
+	Title            string       `json:"title"`
+	BodyHTML         string       `json:"body_html"`
+	PodcastUrl       string       `json:"podcast_url,omitempty"`
+	VideoUpload      *VideoUpload `json:"videoUpload,omitempty"`
+	PodcastUpload    *AudioUpload `json:"podcastUpload,omitempty"`
+	VoiceoverUpload  *AudioUpload `json:"voiceoverUpload,omitempty"`
+}
+
+type VideoUpload struct {
+	Id             string       `json:"id"`
+	Duration       float64      `json:"duration"`
+	ExtractedAudio *AudioUpload `json:"extractedAudio,omitempty"`
+}
+
+type AudioUpload struct {
+	Id       string  `json:"id"`
+	Duration float64 `json:"duration"`
 }
 
 // Static converter instance to avoid recreating it for each conversion


### PR DESCRIPTION
Hi there,

I've been using `sbstck-dl` to archive my Substack library, and it's been fantastic! I noticed that for some premium posts, the native Substack media URLs (video and audio) weren't being exposed on the `Post` struct, which makes it hard for library consumers to back up the actual media files.

I've put together a small PR that:
1. Adds `PodcastUrl`, `VideoUpload`, `PodcastUpload`, and `VoiceoverUpload` to the `Post` struct in `lib/extractor.go`.
2. This safely unmarshals the media URLs that are already present in the embedded `window._preloads` JSON on premium posts.

This change is purely additive and ensures folks can script their own media downloads using the rich metadata extracted by `sbstck-dl`. 

Let me know if there's anything you'd like me to change!
